### PR TITLE
Add database storage for scheduler

### DIFF
--- a/DimSchedule.sln
+++ b/DimSchedule.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler.Web", "Scheduler.Web\Scheduler.Web.csproj", "{44E01E8A-AC62-4EAC-A657-0BCD4160E19B}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {44E01E8A-AC62-4EAC-A657-0BCD4160E19B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {44E01E8A-AC62-4EAC-A657-0BCD4160E19B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {44E01E8A-AC62-4EAC-A657-0BCD4160E19B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {44E01E8A-AC62-4EAC-A657-0BCD4160E19B}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # DimSchedule
+
+This repository contains a minimal ASP.NET MVC (targeting .NET Framework 4.8) sample demonstrating a simple scheduler website. The project is located in the `Scheduler.Web` folder and can be opened with Visual Studio 2019 or later.
+
+## Features
+
+- Forms authentication with a basic login page (`admin` / `password`).
+- Main page displayed after login.
+- Ability to create a schedule item with immediate or scheduled execution time.
+- Data stored in a local database using Entity Framework.
+- History page that lists all created schedule items along with their execution details.
+
+## Building
+
+Open `DimSchedule.sln` in Visual Studio and restore NuGet packages to build and run the application. Entity Framework will automatically create a LocalDB database named `ScheduleDb` on first run using the connection string in `web.config`.

--- a/Scheduler.Web/App_Start/RouteConfig.cs
+++ b/Scheduler.Web/App_Start/RouteConfig.cs
@@ -1,0 +1,19 @@
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace Scheduler.Web
+{
+    public class RouteConfig
+    {
+        public static void RegisterRoutes(RouteCollection routes)
+        {
+            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+            routes.MapRoute(
+                name: "Default",
+                url: "{controller}/{action}/{id}",
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+            );
+        }
+    }
+}

--- a/Scheduler.Web/Controllers/AccountController.cs
+++ b/Scheduler.Web/Controllers/AccountController.cs
@@ -1,0 +1,37 @@
+using System.Web.Mvc;
+using Scheduler.Web.Models;
+using System.Web.Security;
+
+namespace Scheduler.Web.Controllers
+{
+    public class AccountController : Controller
+    {
+        private const string UserName = "admin";
+        private const string Password = "password";
+
+        [AllowAnonymous]
+        public ActionResult Login()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public ActionResult Login(LoginModel model)
+        {
+            if (ModelState.IsValid && model.UserName == UserName && model.Password == Password)
+            {
+                FormsAuthentication.SetAuthCookie(model.UserName, false);
+                return RedirectToAction("Index", "Home");
+            }
+            ModelState.AddModelError("", "Invalid username or password.");
+            return View(model);
+        }
+
+        public ActionResult Logout()
+        {
+            FormsAuthentication.SignOut();
+            return RedirectToAction("Login");
+        }
+    }
+}

--- a/Scheduler.Web/Controllers/HomeController.cs
+++ b/Scheduler.Web/Controllers/HomeController.cs
@@ -1,0 +1,13 @@
+using System.Web.Mvc;
+
+namespace Scheduler.Web.Controllers
+{
+    [Authorize]
+    public class HomeController : Controller
+    {
+        public ActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/Scheduler.Web/Controllers/ScheduleController.cs
+++ b/Scheduler.Web/Controllers/ScheduleController.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Web.Mvc;
+using Scheduler.Web.Models;
+
+namespace Scheduler.Web.Controllers
+{
+    [Authorize]
+    public class ScheduleController : Controller
+    {
+        private ScheduleContext db = new ScheduleContext();
+
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public ActionResult Create(ScheduleItem model)
+        {
+            if (ModelState.IsValid)
+            {
+                if (model.IsImmediate)
+                {
+                    model.ScheduledTime = DateTime.Now;
+                }
+                db.Schedules.Add(model);
+                db.SaveChanges();
+                db.Logs.Add(new ScheduleLog
+                {
+                    ScheduleId = model.Id,
+                    ExecutionTime = model.ScheduledTime,
+                    Result = "Scheduled"
+                });
+                db.SaveChanges();
+                return RedirectToAction("History");
+            }
+            return View(model);
+        }
+
+        public ActionResult History()
+        {
+            var records = from item in db.Schedules
+                          join log in db.Logs on item.Id equals log.ScheduleId
+                          select new ScheduleRecord { Item = item, Log = log };
+            return View(records.ToList());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                db.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Scheduler.Web/Global.asax
+++ b/Scheduler.Web/Global.asax
@@ -1,0 +1,1 @@
+<%@ Application Inherits="Scheduler.Web.MvcApplication" %>

--- a/Scheduler.Web/Global.asax.cs
+++ b/Scheduler.Web/Global.asax.cs
@@ -1,0 +1,14 @@
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace Scheduler.Web
+{
+    public class MvcApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            RouteConfig.RegisterRoutes(RouteTable.Routes);
+        }
+    }
+}

--- a/Scheduler.Web/Models/LoginModel.cs
+++ b/Scheduler.Web/Models/LoginModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Scheduler.Web.Models
+{
+    public class LoginModel
+    {
+        [Required]
+        public string UserName { get; set; }
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; }
+    }
+}

--- a/Scheduler.Web/Models/ScheduleContext.cs
+++ b/Scheduler.Web/Models/ScheduleContext.cs
@@ -1,0 +1,14 @@
+using System.Data.Entity;
+
+namespace Scheduler.Web.Models
+{
+    public class ScheduleContext : DbContext
+    {
+        public ScheduleContext() : base("ScheduleContext")
+        {
+        }
+
+        public DbSet<ScheduleItem> Schedules { get; set; }
+        public DbSet<ScheduleLog> Logs { get; set; }
+    }
+}

--- a/Scheduler.Web/Models/ScheduleItem.cs
+++ b/Scheduler.Web/Models/ScheduleItem.cs
@@ -1,0 +1,15 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Scheduler.Web.Models
+{
+    public class ScheduleItem
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Name { get; set; }
+        public bool IsImmediate { get; set; }
+        [DataType(DataType.DateTime)]
+        public DateTime ScheduledTime { get; set; }
+    }
+}

--- a/Scheduler.Web/Models/ScheduleLog.cs
+++ b/Scheduler.Web/Models/ScheduleLog.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Scheduler.Web.Models
+{
+    public class ScheduleLog
+    {
+        public int Id { get; set; }
+        public int ScheduleId { get; set; }
+        public DateTime ExecutionTime { get; set; }
+        public string Result { get; set; }
+    }
+
+    public class ScheduleRecord
+    {
+        public ScheduleItem Item { get; set; }
+        public ScheduleLog Log { get; set; }
+    }
+}

--- a/Scheduler.Web/Scheduler.Web.csproj
+++ b/Scheduler.Web/Scheduler.Web.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.7" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+  </ItemGroup>
+</Project>

--- a/Scheduler.Web/Views/Account/Login.cshtml
+++ b/Scheduler.Web/Views/Account/Login.cshtml
@@ -1,0 +1,19 @@
+@model Scheduler.Web.Models.LoginModel
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h2>Login</h2>
+@using (Html.BeginForm())
+{
+    @Html.LabelFor(m => m.UserName)
+    @Html.TextBoxFor(m => m.UserName)
+    <br />
+    @Html.LabelFor(m => m.Password)
+    @Html.PasswordFor(m => m.Password)
+    <br />
+    <input type="submit" value="Login" />
+}
+@if (!ViewData.ModelState.IsValid)
+{
+    <div>@Html.ValidationSummary()</div>
+}

--- a/Scheduler.Web/Views/Home/Index.cshtml
+++ b/Scheduler.Web/Views/Home/Index.cshtml
@@ -1,0 +1,8 @@
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h2>Main Page</h2>
+<p>
+    @Html.ActionLink("Create Schedule", "Create", "Schedule") |
+    @Html.ActionLink("View Logs", "History", "Schedule")
+</p>

--- a/Scheduler.Web/Views/Schedule/Create.cshtml
+++ b/Scheduler.Web/Views/Schedule/Create.cshtml
@@ -1,0 +1,17 @@
+@model Scheduler.Web.Models.ScheduleItem
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h2>Create Schedule</h2>
+@using (Html.BeginForm())
+{
+    @Html.LabelFor(m => m.Name)
+    @Html.TextBoxFor(m => m.Name)
+    <br />
+    @Html.CheckBoxFor(m => m.IsImmediate) Immediate
+    <br />
+    @Html.LabelFor(m => m.ScheduledTime)
+    @Html.TextBoxFor(m => m.ScheduledTime, new { type = "datetime-local" })
+    <br />
+    <input type="submit" value="Create" />
+}

--- a/Scheduler.Web/Views/Schedule/History.cshtml
+++ b/Scheduler.Web/Views/Schedule/History.cshtml
@@ -1,0 +1,20 @@
+@model IEnumerable<Scheduler.Web.Models.ScheduleRecord>
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h2>Schedule History</h2>
+<table>
+    <tr>
+        <th>Name</th>
+        <th>Time</th>
+        <th>Result</th>
+    </tr>
+@foreach (var record in Model)
+{
+    <tr>
+        <td>@record.Item.Name</td>
+        <td>@record.Log.ExecutionTime</td>
+        <td>@record.Log.Result</td>
+    </tr>
+}
+</table>

--- a/Scheduler.Web/Views/Shared/_Layout.cshtml
+++ b/Scheduler.Web/Views/Shared/_Layout.cshtml
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Scheduler</title>
+</head>
+<body>
+    <div>
+        @if (User.Identity.IsAuthenticated)
+        {
+            <span>Hello @User.Identity.Name | </span>
+            @Html.ActionLink("Logout", "Logout", "Account")
+        }
+    </div>
+    <div>
+        @RenderBody()
+    </div>
+</body>
+</html>

--- a/Scheduler.Web/web.config
+++ b/Scheduler.Web/web.config
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<configuration>
+  <connectionStrings>
+    <add name="ScheduleContext"
+         connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=ScheduleDb;Integrated Security=True"
+         providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8" />
+    <authentication mode="Forms">
+      <forms loginUrl="~/Account/Login" timeout="2880" />
+    </authentication>
+  </system.web>
+</configuration>


### PR DESCRIPTION
## Summary
- switch schedule and log storage to Entity Framework with LocalDB
- add ScheduleContext and connection string
- update csproj with EntityFramework package
- document database usage in README

## Testing
- `dotnet build DimSchedule.sln` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841cbf8dd18832e908a47bf6f876ffc